### PR TITLE
improved dockerbuild

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,10 @@ ENV COMMIT_HASH=$COMMIT_HASH
 ARG DIRTY
 ENV DIRTY=$DIRTY
 
-COPY go.* /src
+COPY go.* /src/
 RUN go mod download
 
-COPY . /src
+COPY . /src/
 RUN set -ex \
     && echo --ldflags "-extldflags '-static' -X main.Version=${RELEASE_DATE} -X main.CommitHash=${COMMIT_HASH}${DIRTY}" \
     && go install --ldflags "-extldflags '-static' -X main.Version=${RELEASE_DATE} -X main.CommitHash=${COMMIT_HASH}${DIRTY}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,11 +19,11 @@ RUN set -ex \
     && apk del --no-cache .build-deps
 CMD ["/app/docker-plugin-seaweedfs"]
 
-FROM alpine
+FROM alpine:latest
 ####
 # Install SeaweedFS Client
 ####
-ARG SEAWEEDFS_VERSION=1.44
+ARG SEAWEEDFS_VERSION=1.52
 ENV SEAWEEDFS_VERSION=$SEAWEEDFS_VERSION
 RUN apk upgrade --no-cache && \
     apk add --no-cache fuse && \
@@ -34,10 +34,10 @@ RUN apk upgrade --no-cache && \
     rm -rf /tmp/*
 
 # I have a docker socket, and this may help me test
-ARG DOCKER_VERSION=19.03.4
+ARG DOCKER_VERSION=19.03.5
 ENV DOCKER_VERSION=$DOCKER_VERSION
 RUN cd /tmp \
-    && wget https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz \
+    && wget --quiet https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz \
     && tar zxvf docker-${DOCKER_VERSION}.tgz \
     && cp docker/docker /bin/ \
     && rm -rf docker*
@@ -47,5 +47,5 @@ RUN echo "user_allow_other" >> /etc/fuse.conf
 
 RUN mkdir -p /run/docker/plugins /mnt/state /mnt/volumes
 
-COPY --from=builder /go/bin/docker-plugin-seaweedfs .
+COPY --from=builder /app/docker-plugin-seaweedfs .
 CMD ["/docker-plugin-seaweedfs"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN set -ex \
     && go install --ldflags "-extldflags '-static' -X main.Version=${RELEASE_DATE} -X main.CommitHash=${COMMIT_HASH}${DIRTY}"
 
 RUN set -ex \
-    && apk del .build-deps
+    && apk del --no-cache .build-deps
 CMD ["/go/bin/docker-plugin-seaweedfs"]
 
 FROM alpine
@@ -30,12 +30,12 @@ FROM alpine
 ####
 ARG SEAWEEDFS_VERSION=1.44
 ENV SEAWEEDFS_VERSION=$SEAWEEDFS_VERSION
-RUN apk update && \
-    apk add fuse && \
-    apk add --no-cache --virtual build-dependencies --update wget curl ca-certificates && \
+RUN apk upgrade --no-cache && \
+    apk add --no-cache fuse && \
+    apk add --no-cache --virtual build-dependencies ca-certificates && \
     wget -qO /tmp/linux_amd64.tar.gz https://github.com/chrislusf/seaweedfs/releases/download/${SEAWEEDFS_VERSION}/linux_amd64.tar.gz && \
     tar -C /usr/bin/ -xzvf /tmp/linux_amd64.tar.gz && \
-    apk del build-dependencies && \
+    apk del --no-cache build-dependencies && \
     rm -rf /tmp/*
 
 # I have a docker socket, and this may help me test

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ ENV COMMIT_HASH=$COMMIT_HASH
 ARG DIRTY
 ENV DIRTY=$DIRTY
 
-COPY . /src/
+COPY *.go /src/
 
 RUN set -ex \
     && go install --ldflags "-extldflags '-static' -X main.Version=${RELEASE_DATE} -X main.CommitHash=${COMMIT_HASH}${DIRTY}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,8 @@ FROM alpine:latest
 ####
 ARG SEAWEEDFS_VERSION=1.52
 ENV SEAWEEDFS_VERSION=$SEAWEEDFS_VERSION
+ARG PLUGIN_IMAGE_ROOTFS_TAG
+ENV PLUGIN_IMAGE_ROOTFS_TAG=$PLUGIN_IMAGE_ROOTFS_TAG
 RUN apk upgrade --no-cache && \
     apk add --no-cache fuse && \
     apk add --no-cache --virtual build-dependencies ca-certificates && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,11 @@
 FROM golang:1.13-alpine as builder
 
+WORKDIR /src
+COPY go.* /src/
+
+RUN set -ex \
+    && go mod download
+
 ARG RELEASE_DATE
 ENV RELEASE_DATE=$RELEASE_DATE
 ARG COMMIT_HASH
@@ -7,17 +13,11 @@ ENV COMMIT_HASH=$COMMIT_HASH
 ARG DIRTY
 ENV DIRTY=$DIRTY
 
-WORKDIR /src
 COPY . /src/
 
 RUN set -ex \
-    && apk add --no-cache --virtual .build-deps gcc libc-dev git \
-    && go mod download \
-    && go install --ldflags "-extldflags '-static' -X main.Version=${RELEASE_DATE} -X main.CommitHash=${COMMIT_HASH}${DIRTY}" \
-    && mkdir -p /app && cp -p $GOPATH/bin/docker-plugin-seaweedfs /app \
-    && rm -rf $GOPATH \
-    && apk del --no-cache .build-deps
-CMD ["/app/docker-plugin-seaweedfs"]
+    && go install --ldflags "-extldflags '-static' -X main.Version=${RELEASE_DATE} -X main.CommitHash=${COMMIT_HASH}${DIRTY}"
+CMD ["/go/bin/docker-plugin-seaweedfs"]
 
 FROM alpine:latest
 ####
@@ -27,27 +27,23 @@ ARG SEAWEEDFS_VERSION=1.52
 ENV SEAWEEDFS_VERSION=$SEAWEEDFS_VERSION
 ARG PLUGIN_IMAGE_ROOTFS_TAG
 ENV PLUGIN_IMAGE_ROOTFS_TAG=$PLUGIN_IMAGE_ROOTFS_TAG
-RUN apk upgrade --no-cache && \
-    apk add --no-cache fuse && \
-    apk add --no-cache --virtual build-dependencies ca-certificates && \
-    wget -qO /tmp/linux_amd64.tar.gz https://github.com/chrislusf/seaweedfs/releases/download/${SEAWEEDFS_VERSION}/linux_amd64.tar.gz && \
-    tar -C /usr/bin/ -xzvf /tmp/linux_amd64.tar.gz && \
-    apk del --no-cache build-dependencies && \
-    rm -rf /tmp/*
-
 # I have a docker socket, and this may help me test
 ARG DOCKER_VERSION=19.03.5
 ENV DOCKER_VERSION=$DOCKER_VERSION
-RUN cd /tmp \
-    && wget --quiet https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz \
-    && tar zxvf docker-${DOCKER_VERSION}.tgz \
-    && cp docker/docker /bin/ \
-    && rm -rf docker*
+
+RUN apk upgrade --no-cache \
+    && apk add --no-cache fuse \
+    && apk add --no-cache --virtual build-dependencies ca-certificates tar \
+    && wget --quiet -O - https://github.com/chrislusf/seaweedfs/releases/download/${SEAWEEDFS_VERSION}/linux_amd64.tar.gz | \
+        tar xzvf - -C /usr/bin/ \
+    && wget --quiet -O - https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz | \
+        tar xzvf - -C /bin --strip-components=1 docker/docker \
+    && apk del --no-cache build-dependencies
 
 # let non-root users fusemount
 RUN echo "user_allow_other" >> /etc/fuse.conf
 
 RUN mkdir -p /run/docker/plugins /mnt/state /mnt/volumes
 
-COPY --from=builder /app/docker-plugin-seaweedfs .
+COPY --from=builder /go/bin/docker-plugin-seaweedfs .
 CMD ["/docker-plugin-seaweedfs"]

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,11 @@
 PREFIX = svendowideit/seaweedfs-volume
 PLUGIN_NAME = ${PREFIX}-plugin
 PLUGIN_TAG ?= develop
+PLUGIN_IMAGE_ROOTFS = ${PLUGIN_NAME}-rootfs
+PLUGIN_IMAGE_ROOTFS_TAG = ${PLUGIN_IMAGE_ROOTFS}:${PLUGIN_TAG}
+PLUGIN_BUILD_IMAGE_ROOTFS_TAG = ${PLUGIN_IMAGE_ROOTFS}:build-${PLUGIN_TAG}
+DOCKER_VERSION ?= 19.03.5
+SEAWEEDFS_VERSION ?= 1.52
 
 RELEASE_DATE=$(shell date +%F)
 COMMIT_HASH=$(shell git rev-parse --short HEAD 2>/dev/null)
@@ -21,22 +26,32 @@ clean:
 	@rm -rf ./plugin
 
 rootfs:
-	@echo "### docker build: rootfs image with ${PLUGIN_NAME}-rootfs (${RELEASE_DATE}) ${COMMIT_HASH}${DIRTY}"
+	@echo "### docker build: rootfs image with ${PLUGIN_IMAGE_ROOTFS} (${RELEASE_DATE}) ${COMMIT_HASH}${DIRTY}"
 	@echo "${GITSTATUS}"
-	@docker build --target builder -t ${PLUGIN_NAME}-rootfs:build-${PLUGIN_TAG} --build-arg "RELEASE_DATE=${RELEASE_DATE}" --build-arg "COMMIT_HASH=${COMMIT_HASH}" --build-arg "DIRTY=${DIRTY}" .
-	@docker build -t ${PLUGIN_NAME}-rootfs:${PLUGIN_TAG} --build-arg "RELEASE_DATE=${RELEASE_DATE}" --build-arg "COMMIT_HASH=${COMMIT_HASH}" --build-arg "DIRTY=${DIRTY}" .
+	@docker build --target builder -t ${PLUGIN_BUILD_IMAGE_ROOTFS_TAG} \
+		--build-arg "RELEASE_DATE=${RELEASE_DATE}" \
+		--build-arg "COMMIT_HASH=${COMMIT_HASH}" \
+		--build-arg "DIRTY=${DIRTY}" \
+		.
+	@docker build -t ${PLUGIN_IMAGE_ROOTFS_TAG} \
+		--build-arg "RELEASE_DATE=${RELEASE_DATE}" \
+		--build-arg "COMMIT_HASH=${COMMIT_HASH}" \
+		--build-arg "DIRTY=${DIRTY}" \
+		--build-arg "DOCKER_VERSION=${DOCKER_VERSION}" \
+		--build-arg "SEAWEEDFS_VERSION=${SEAWEEDFS_VERSION}" \
+		.
 	@echo "### create rootfs directory in ./plugin/rootfs"
 	@mkdir -p ./plugin/rootfs
-	@docker create --name tmp ${PLUGIN_NAME}-rootfs:${PLUGIN_TAG}
+	@docker create --name tmp ${PLUGIN_IMAGE_ROOTFS_TAG}
 	@docker export tmp | tar -x -C ./plugin/rootfs
 	@echo "### add version into to config.json and stage into ./plugin/"
 	@RELEASE_DATE=${RELEASE_DATE} COMMIT_HASH=${COMMIT_HASH} DIRTY=${DIRTY} envsubst > ./plugin/config.json < config.json
 	@docker rm -vf tmp
 
 push-rootfs: rootfs
-	@echo "### push rootfs ${PLUGIN_NAME}:${PLUGIN_TAG}"
-	@docker push ${PLUGIN_NAME}-rootfs:build-${PLUGIN_TAG}
-	@docker push ${PLUGIN_NAME}-rootfs:${PLUGIN_TAG}
+	@echo "### push rootfs ${PLUGIN_IMAGE_ROOTFS}"
+	@docker push ${PLUGIN_BUILD_IMAGE_ROOTFS_TAG}
+	@docker push ${PLUGIN_IMAGE_ROOTFS_TAG}
 
 run-rootfs:
 	@docker run --rm -it \
@@ -46,7 +61,7 @@ run-rootfs:
 		-v /run:/run \
 		--net=seaweedfs_internal \
 		-e DEBUG=true \
-		${PLUGIN_NAME}-rootfs:${PLUGIN_TAG}
+		${PLUGIN_IMAGE_ROOTFS_TAG}
 
 create:
 	@echo "### remove existing plugin swarm if exists"
@@ -58,7 +73,7 @@ create:
 
 #TODO: add an "ensure seaweedfs stack is up and running step that is used by "make all"
 
-enable:		
+enable:
 	@echo "### enable plugin ${PLUGIN_NAME}:${PLUGIN_TAG}"
 	@docker plugin enable ${PLUGIN_NAME}:${PLUGIN_TAG}
 
@@ -99,16 +114,14 @@ test:
 # TODO: need a test-clean that removes the dirs from seaweedfs
 # TODO: and some way to "start over" (atm, remove the seaweedfs stack, remove the volumes)
 
-
 mountall:
 	@docker run --rm -it --net=seaweedfs_internal --cap-add=SYS_ADMIN --device=/dev/fuse:/dev/fuse --security-opt=apparmor:unconfined --entrypoint=weed ${PLUGIN_NAME}:${PLUGIN_TAG} mount -filer=filer:8888 -dir=/mnt -filer.path=/
-
 
 logs:
 	@sudo journalctl -fu docker | grep $(shell docker plugin inspect --format "{{.Id}}" ${PLUGIN_NAME}:${PLUGIN_TAG})
 
 push:  clean rootfs create enable
 	@echo "### push plugin ${PLUGIN_NAME}:${PLUGIN_TAG}"
-	@docker push ${PLUGIN_NAME}-rootfs:build-${PLUGIN_TAG}
-	@docker push ${PLUGIN_NAME}-rootfs:${PLUGIN_TAG}
+	@docker push ${PLUGIN_BUILD_IMAGE_ROOTFS_TAG}
+	@docker push ${PLUGIN_IMAGE_ROOTFS_TAG}
 	@docker plugin push ${PLUGIN_NAME}:${PLUGIN_TAG}

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: all build clean rootfs create enable ps enter test mountall logs push
 
-PREFIX = svendowideit/seaweedfs-volume
+PREFIX ?= svendowideit/seaweedfs-volume
 PLUGIN_NAME = ${PREFIX}-plugin
 PLUGIN_TAG ?= develop
 PLUGIN_IMAGE_ROOTFS = ${PLUGIN_NAME}-rootfs

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ rootfs:
 		--build-arg "DIRTY=${DIRTY}" \
 		--build-arg "DOCKER_VERSION=${DOCKER_VERSION}" \
 		--build-arg "SEAWEEDFS_VERSION=${SEAWEEDFS_VERSION}" \
+		--build-arg "PLUGIN_IMAGE_ROOTFS_TAG=${PLUGIN_IMAGE_ROOTFS_TAG}" \
 		.
 	@echo "### create rootfs directory in ./plugin/rootfs"
 	@mkdir -p ./plugin/rootfs


### PR DESCRIPTION
In order to improve the flexibility of the current work and being able to test it with a different docker image, I extended the docker build.

- DRY the Makefile
- added ability to pass docker plugin rootfs image location to docker build
- prepared for modification of main.go, ability to inject plugin rootfs location by environment variable (upcoming pull request)
- updated to go 1.13
- added ability to use newer seaweedfs version